### PR TITLE
fix a bug, when request json String serialize to python object , miss…

### DIFF
--- a/scrapy_distributed/queues/amqp.py
+++ b/scrapy_distributed/queues/amqp.py
@@ -193,6 +193,7 @@ class RabbitQueue(IQueue):
             priority=d.get("priority", 0),
             dont_filter=d.get("dont_filter", True),
             flags=d.get("flags", None),
+            cb_kwargs=d.get('cb_kwargs', None),
         )
 
     @classmethod


### PR DESCRIPTION
if scrapy.request set prarameter cb_kwargs , for example:
`scrapy.Request(url=server,
                              method='POST',
                              headers={"Content-Type": "application/json"},
                              body=json.dumps(body),
                              dont_filter=True,
                              meta=meta,
                              callback=self.spider.proc_result_p,
                              cb_kwargs={'req_type': body.get('type', 'unknown')})`

then process response will throw exception 