### PR TITLE
Fix reconnect retry logic

### DIFF
--- a/scrapy_distributed/queues/amqp.py
+++ b/scrapy_distributed/queues/amqp.py
@@ -26,11 +26,13 @@ def _try_operation(function):
 
     def wrapper(self, *args, **kwargs):
         retries = 0
+        last_exception = None
         while retries < 10:
             try:
                 return function(self, *args, **kwargs)
             except Exception as e:
                 retries += 1
+                last_exception = e
                 msg = "Function %s failed. Reconnecting... (%d times)" % (
                     str(function),
                     retries,
@@ -38,7 +40,8 @@ def _try_operation(function):
                 logger.error(msg)
                 self.connect()
                 time.sleep((retries - 1) * 5)
-                raise e
+        if last_exception:
+            raise last_exception
         return None
 
     return wrapper

--- a/scrapy_distributed/queues/kafka.py
+++ b/scrapy_distributed/queues/kafka.py
@@ -26,11 +26,13 @@ def _try_operation(function):
 
     def wrapper(self, *args, **kwargs):
         retries = 0
+        last_exception = None
         while retries < 10:
             try:
                 return function(self, *args, **kwargs)
             except Exception as e:
                 retries += 1
+                last_exception = e
                 msg = "Function %s failed. Reconnecting... (%d times)" % (
                     str(function),
                     retries,
@@ -38,7 +40,8 @@ def _try_operation(function):
                 logger.error(msg)
                 self.connect()
                 time.sleep((retries - 1) * 5)
-                raise e
+        if last_exception:
+            raise last_exception
         return None
 
     return wrapper


### PR DESCRIPTION
## Summary
- fix rabbit and kafka queue retry decorator

## Testing
- `python -m compileall -q scrapy_distributed`

------
https://chatgpt.com/codex/tasks/task_e_6848516c163c8322be5289272dcc3440