### PR TITLE
Fix outdated example path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/Insutanto/scrapy-distributed.git && cd scrapy-distr
 && python setup.py install
 ```
 
-There is a simple demo in [`examples/simple_example`]((examples/)). Here is the fast way to use `Scrapy-Distributed`.
+There are example projects in `examples/rabbitmq_example` and `examples/kafka_example`. Here is the fast way to use `Scrapy-Distributed`.
 
 ### [Examples of RabbitMQ](examples/rabbitmq_example)
 


### PR DESCRIPTION
## Summary
- fix outdated example path for simple demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848576078f88322a7ebf62e0e7a4cd6