### PR TITLE
Fix KafkaPipeline close consumer issue

### DIFF
--- a/scrapy_distributed/pipelines/kafka.py
+++ b/scrapy_distributed/pipelines/kafka.py
@@ -74,7 +74,14 @@ class KafkaPipeline(object):
 
     def close(self):
         """Close channel"""
-        self.admin_client.close()
-        self.producer.close()
-        self.consumer.close()
+        if self.admin_client:
+            try:
+                self.admin_client.close()
+            except Exception:
+                pass
+        if self.producer:
+            try:
+                self.producer.close()
+            except Exception:
+                pass
         logger.error("kafka pipeline channel is closed")


### PR DESCRIPTION
## Summary
- fix `KafkaPipeline.close` so it closes only initialized resources

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848596db8c48322b5facde0ba85c707